### PR TITLE
standardize ADMINMSP constant set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This package contains the code for the Blossom Smart Contracts. There are two Sm
 Before installing chaincode, you must update the ADMINMSP constant in **both the asset and authorization source code**.
 To do so, navigate to the following files:
 
-- Asset: [./src/main/java/ngac/MSPConfig](./asset/src/main/java/ngac/MSPConfig)
-- Authorization: [./src/main/java/ngac/MSPConfig](./asset/src/main/java/ngac/MSPConfig)
+- Asset: [./asset/src/main/java/ngac/MSPConfig.java#L7](./asset/src/main/java/ngac/MSPConfig.java#L7)
+- Authorization: [./authorization/src/main/java/ngac/MSPConfig.java#L7](./authorization/src/main/java/ngac/MSPConfig.java#L7)
 
 and update the value of the `ADMINMSP` constant in both files to the MSPID of the admin member of the blossom deployment. 
 For example:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ For example:
 
 `public static final String ADMINMSP = "m-A1B2C3D4E5F6G6H7I8J9KALBMCND";`
 
+Use the following command to find the files using the command line:
+
+`grep -r 'public static final String ADMINMSP' *`
+
 ## E2E Tests
 From `./e2e`, run `make fabirc-up` to start a local Fabric test network. There are two tests:
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 This package contains the code for the Blossom Smart Contracts. There are two Smart Contracts: [Authorization](./authorization) and [Asset](./asset).
 
+## Chaincode Installation
+Before installing chaincode, you must update the ADMINMSP constant in **both the asset and authorization source code**.
+To do so, navigate to the following files:
+
+- Asset: [./src/main/java/ngac/MSPConfig](./asset/src/main/java/ngac/MSPConfig)
+- Authorization: [./src/main/java/ngac/MSPConfig](./asset/src/main/java/ngac/MSPConfig)
+
+and update the value of the `ADMINMSP` constant in both files to the MSPID of the admin member of the blossom deployment. 
+For example:
+
+`public static final String ADMINMSP = "m-A1B2C3D4E5F6G6H7I8J9KALBMCND";`
+
 ## E2E Tests
 From `./e2e`, run `make fabirc-up` to start a local Fabric test network. There are two tests:
 

--- a/asset/README.md
+++ b/asset/README.md
@@ -3,7 +3,7 @@
 Chaincode functions to handle the Blossom asset use case. See design document:  https://github.com/usnistgov/blossom-nist-member/wiki/BloSS@M:-Asset-Channel-Design.
 
 ## Set ADMINMSP value
-In [./src/main/java/ngac/PolicyBuilder.java](./src/main/java/ngac/PolicyBuilder.java) set the value of the `ADMINMSP` constant
+In [./src/main/java/ngac/MSPConfig.java](./src/main/java/ngac/MSPConfig.java) set the value of the `ADMINMSP` constant
 variable to the MSPID of the Blossom Admin member. **This value should be the same as the value set for the authorization chaincode**.
 
 ## Build Chaincode

--- a/asset/src/main/java/contract/AssetContract.java
+++ b/asset/src/main/java/contract/AssetContract.java
@@ -5,6 +5,7 @@ import contract.response.AssetDetailResponse;
 import contract.response.AssetResponse;
 import contract.response.IdResponse;
 import model.*;
+import ngac.MSPConfig;
 import ngac.PDP;
 import org.hyperledger.fabric.Logger;
 import org.hyperledger.fabric.contract.Context;
@@ -17,13 +18,10 @@ import org.hyperledger.fabric.shim.ledger.KeyModification;
 import org.hyperledger.fabric.shim.ledger.KeyValue;
 import org.hyperledger.fabric.shim.ledger.QueryResultsIterator;
 
-import java.time.Instant;
 import java.util.*;
 
-import static model.DateFormatter.isExpired;
 import static model.LicenseKey.hashedLicenseKey;
 import static model.LicenseKey.licenseKey;
-import static ngac.PolicyBuilder.ADMINMSP;
 
 @Contract(
         name = "asset",
@@ -35,7 +33,7 @@ import static ngac.PolicyBuilder.ADMINMSP;
 )
 public class AssetContract implements ContractInterface {
 
-    public static final String  ADMINMSP_IPDC = accountIPDC(ADMINMSP);
+    public static final String  ADMINMSP_IPDC = accountIPDC(MSPConfig.ADMINMSP);
     public static final String ASSET_PREFIX = "asset:";
 
     private static final Logger log = Logger.getLogger(AssetContract.class);

--- a/asset/src/main/java/ngac/MSPConfig.java
+++ b/asset/src/main/java/ngac/MSPConfig.java
@@ -1,0 +1,9 @@
+package ngac;
+
+public class MSPConfig {
+
+	// Specify the MSPID of the Admin member of the blossom deployment
+	// The value should be set to "Org1MSP" if running the JUnit tests
+	public static final String ADMINMSP = "Org1MSP"; // e.g. m-A1B2C3D4E5F6G6H7I8J9KALBMCND
+
+}

--- a/asset/src/main/java/ngac/PolicyBuilder.java
+++ b/asset/src/main/java/ngac/PolicyBuilder.java
@@ -29,11 +29,6 @@ import static model.Status.*;
 
 public class PolicyBuilder {
 
-    /*
-    update to ADMINMSP of deployment
-     */
-    public static final String ADMINMSP = "Org1MSP";
-
     // roles
     public static final String BLOSSOM_ROLE_ATTR = "blossom.role";
     public static final String ACQ_OFFICER = "Acquisition Officer";
@@ -82,7 +77,7 @@ public class PolicyBuilder {
 
         // deny non adminmsp ACQ eleveated privs on assets
         String cidAccount = ctx.getClientIdentity().getMSPID();
-        if (!cidAccount.equals(ADMINMSP)) {
+        if (!cidAccount.equals(MSPConfig.ADMINMSP)) {
             pap.modify().prohibitions().createProhibition(
                     "deny non-adminmsp ACQ",
                     ProhibitionSubject.userAttribute(ACQ_OFFICER),
@@ -106,7 +101,7 @@ public class PolicyBuilder {
         pap.modify().graph().createObject(accountTarget, List.of(targetAccountOA, "RBAC/account", "Status/account"));
 
         // if the targetAccountUA exists, then the request is from the same account, associate the ua and oa
-        // otherwise do nothing as the accounts dont match, adminmsp will be taken care of in following block
+        // otherwise do nothing as the accounts don't match, adminmsp will be taken care of in following block
         String targetAccountUA = accountUA(targetAccount);
         if (pap.query().graph().nodeExists(targetAccountUA)) {
             pap.modify().graph().associate(targetAccountUA, targetAccountOA, new AccessRightSet(ALL_ACCESS_RIGHTS));
@@ -115,7 +110,7 @@ public class PolicyBuilder {
         // if cid is adminmsp, grant access to target account oa and
         // deny adminmsp elevated privs on account target
         String cidAccount = ctx.getClientIdentity().getMSPID();
-        if (cidAccount.equals(ADMINMSP)) {
+        if (cidAccount.equals(MSPConfig.ADMINMSP)) {
             String cidAcctUA = accountUA(cidAccount);
             pap.modify().graph().associate(cidAcctUA, targetAccountOA, new AccessRightSet(ALL_ACCESS_RIGHTS));
 
@@ -253,8 +248,8 @@ public class PolicyBuilder {
 
         // if adminmsp only SO and ACQ are allowed roles
         // if not adminmsp only TPOC and ACQ are allowed roles
-        if ((account.equals(ADMINMSP) && !(role.equals(LICENSE_OWNER) || role.equals(ACQ_OFFICER))) ||
-                (!account.equals(ADMINMSP) && !(role.equals(TPOC) || role.equals(ACQ_OFFICER)))) {
+        if ((account.equals(MSPConfig.ADMINMSP) && !(role.equals(LICENSE_OWNER) || role.equals(ACQ_OFFICER))) ||
+                (!account.equals(MSPConfig.ADMINMSP) && !(role.equals(TPOC) || role.equals(ACQ_OFFICER)))) {
             throw new ChaincodeException("invalid role " + role);
         }
 

--- a/authorization/README.md
+++ b/authorization/README.md
@@ -3,7 +3,7 @@
 Chaincode functions to handle Blossom authorization. See design document: https://github.com/usnistgov/blossom-nist-member/wiki/BloSS@M-ATO-Process.
 
 ## Set ADMINMSP value
-In [./src/main/resources/policy.pml](./src/main/java/ngac/BlossomPDP.java) set the value of the `ADMINMSP` constant to the MSPID of the Blossom Admin member.
+In [./src/main/java/ngac/MSPConfig.java](./src/main/java/ngac/MSPConfig.java) set the value of the `ADMINMSP` constant to the MSPID of the Blossom Admin member.
 
 ## Build Chaincode
 To build the chaincode using Docker with java 11 and gradle 5.6.2, from the authorization directory run:

--- a/authorization/src/main/java/contract/VoteContract.java
+++ b/authorization/src/main/java/contract/VoteContract.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import static contract.AccountContract.accountKey;
 import static model.Status.AUTHORIZED;
-import static ngac.BlossomPDP.ADMINMSP;
+import static ngac.MSPConfig.ADMINMSP;
 
 /**
  * Chaincode functions to support voting on account statuses.

--- a/authorization/src/main/java/ngac/BlossomPDP.java
+++ b/authorization/src/main/java/ngac/BlossomPDP.java
@@ -3,18 +3,15 @@ package ngac;
 import gov.nist.csd.pm.impl.memory.pap.MemoryPAP;
 import gov.nist.csd.pm.pap.PAP;
 import gov.nist.csd.pm.pap.exception.PMException;
-import gov.nist.csd.pm.pap.graph.node.Node;
 import gov.nist.csd.pm.pap.graph.relationship.AccessRightSet;
 import gov.nist.csd.pm.pap.pml.value.StringValue;
 import gov.nist.csd.pm.pap.query.UserContext;
-import gov.nist.csd.pm.pap.query.explain.Explain;
 import gov.nist.csd.pm.pap.serialization.json.JSONDeserializer;
 import gov.nist.csd.pm.pap.serialization.json.JSONSerializer;
 import gov.nist.csd.pm.pap.serialization.pml.PMLDeserializer;
 import gov.nist.csd.pm.pdp.AdminAdjudicationResponse;
 import gov.nist.csd.pm.pdp.Decision;
 import gov.nist.csd.pm.pdp.PDP;
-import gov.nist.csd.pm.pdp.exception.UnauthorizedException;
 import org.apache.commons.io.IOUtils;
 import org.bouncycastle.asn1.x500.AttributeTypeAndValue;
 import org.bouncycastle.asn1.x500.RDN;
@@ -31,20 +28,13 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-
-import static gov.nist.csd.pm.pap.graph.node.NodeType.UA;
 
 /**
  * Provides methods for checking access to Blossom resources and updating the policy as needed.
  */
 public class BlossomPDP {
-
-    // MODIFY VALUE TO MSPID OF ADMIN MEMBER OF NETWORK
-    public static final String ADMINMSP = "Org1MSP";
 
     private static final String BLOSSOM_TARGET = "blossom_target";
     private static final String BLOSSOM_ROLE_ATTR = "blossom.role";
@@ -99,7 +89,7 @@ public class BlossomPDP {
         try {
             // create a new PAP object to compile and execute the PML
             PAP pap = new MemoryPAP();
-            pap.setPMLConstants(Map.of("ADMINMSP", new StringValue(ADMINMSP)));
+            pap.setPMLConstants(Map.of("ADMINMSP", new StringValue(MSPConfig.ADMINMSP)));
             pap.deserialize(userCtx, pml, new PMLDeserializer());
 
             // decide if user can bootstrap blossom
@@ -282,7 +272,7 @@ public class BlossomPDP {
             }
 
             // check if user is blossom admin
-            if (ADMINMSP.equals(mspid) && role.equals(AUTHORIZING_OFFICIAL)) {
+            if (MSPConfig.ADMINMSP.equals(mspid) && role.equals(AUTHORIZING_OFFICIAL)) {
                 pap.modify().graph().assign(userCtx.getUser(), List.of("Blossom Admin"));
             }
         } catch (PMException e) {
@@ -332,7 +322,7 @@ public class BlossomPDP {
 
         try {
             MemoryPAP pap = new MemoryPAP();
-            pap.setPMLConstants(Map.of("ADMINMSP", new StringValue(ADMINMSP)));
+            pap.setPMLConstants(Map.of("ADMINMSP", new StringValue(MSPConfig.ADMINMSP)));
             pap.deserialize(userCtx, json, new JSONDeserializer());
 
             return pap;

--- a/authorization/src/main/java/ngac/MSPConfig.java
+++ b/authorization/src/main/java/ngac/MSPConfig.java
@@ -1,0 +1,9 @@
+package ngac;
+
+public class MSPConfig {
+
+	// Specify the MSPID of the Admin member of the blossom deployment
+	// The value should be set to "Org1MSP" if running the JUnit tests
+	public static final String ADMINMSP = "Org1MSP"; // e.g. m-A1B2C3D4E5F6G6H7I8J9KALBMCND
+
+}

--- a/authorization/src/test/java/contract/VoteContractTest.java
+++ b/authorization/src/test/java/contract/VoteContractTest.java
@@ -12,7 +12,7 @@ import mock.MockEvent;
 import mock.MockIdentity;
 import model.Status;
 import model.Vote;
-import ngac.BlossomPDP;
+import ngac.MSPConfig;
 import org.apache.commons.lang3.SerializationUtils;
 import org.hyperledger.fabric.shim.ChaincodeException;
 import org.junit.jupiter.api.Nested;
@@ -646,7 +646,7 @@ class VoteContractTest {
 
         try {
             PAP pap = new MemoryPAP();
-            pap.setPMLConstants(Map.of("ADMINMSP", new StringValue(BlossomPDP.ADMINMSP)));
+            pap.setPMLConstants(Map.of("ADMINMSP", new StringValue(MSPConfig.ADMINMSP)));
             pap.deserialize(new UserContext(""), json, new JSONDeserializer());
 
             Collection<String> parents = pap.query().graph().getDescendants(targetMember + " users");

--- a/authorization/src/test/resources/policy.pml
+++ b/authorization/src/test/resources/policy.pml
@@ -9,7 +9,7 @@ set resource operations [
     "submit_feedback",
     "initiate_vote",
     "vote",
-    "certify_vote",
+    "certify_vote"
 ]
 
 create pc "ADMIN_MSP_PC"


### PR DESCRIPTION
Standardizes the ADMINMSP constant setup in the Auth and Asset chaincodes by creating identical MSPConfig files in the local ngac packages. I also updated the readmes to reflect this change.