### PR TITLE
remove trailing comma causing PML compile errors

### DIFF
--- a/authorization/src/main/resources/policy.pml
+++ b/authorization/src/main/resources/policy.pml
@@ -9,7 +9,7 @@ set resource operations [
     "submit_feedback",
     "initiate_vote",
     "vote",
-    "certify_vote",
+    "certify_vote"
 ]
 
 create pc "ADMIN_MSP_PC"


### PR DESCRIPTION
Removes PML compile error causing bootstrap method to fail.